### PR TITLE
Fix crash when trying to deselect a no longer existent segment

### DIFF
--- a/MXSegmentedControl/MXSegmentedControl.swift
+++ b/MXSegmentedControl/MXSegmentedControl.swift
@@ -116,7 +116,10 @@ import UIKit
     
     /// The currently selected segment index.
     public private(set) var selectedIndex: Int = 0 {
-        willSet { contentView.segments[selectedIndex].isSelected = false }
+        willSet {
+            guard selectedIndex < contentView.segments.count else { return }
+            contentView.segments[selectedIndex].isSelected = false
+        }
         didSet {
             sendActions(for: .valueChanged)
             contentView.segments[selectedIndex].isSelected = true


### PR DESCRIPTION
MXSegmentedControl crashes when you do the following:

1. Configure a MXSegmentedControl with a number of segments
2. Activate the last segment
3. Remove all segments
4. Add the same number of segments minus one
5. Programatically select an element by calling `MXSegmentedControl.select(index: 0, animated: false)`
6. MXSegmentedControl will crash in selectedIndex's `willSet` because it tries to deselect a segment on a non-existent index

This pull request fixes this by doing a bound check before trying to deselect a segment at an index. Ideally we would also set `selectedIndex` to another value when a segment is removed but because there is no concept on a "no selected element" in MXSegmentedControl this will also crash when calling `removeAll()` and then trying to select an element after reconfiguring the segment control.