### PR TITLE
- changed access level for init(withTitles titles: [String])

### DIFF
--- a/MXSegmentedControl/MXSegmentedControl.swift
+++ b/MXSegmentedControl/MXSegmentedControl.swift
@@ -143,7 +143,7 @@ import UIKit
     /// Initializes and returns a newly allocated segmented control object with the specified titles.
     ///
     /// - Parameter titles: The segments titles.
-    convenience init(withTitles titles: [String]) {
+    public convenience init(withTitles titles: [String]) {
         self.init(frame: CGRect.zero)
         for title in titles {
             append(title: title)


### PR DESCRIPTION
Changed access level from internal to public for init(withTitles titles: [String])
