### PR TITLE
Fix a crash and add a new property.

### DIFF
--- a/MXSegmentedControl/MXSegmentedControl.swift
+++ b/MXSegmentedControl/MXSegmentedControl.swift
@@ -288,7 +288,9 @@ open class MXSegmentedControl: UIControl {
             
             if let scrollView = scrollView, scrollView.isDragging || scrollView.isDecelerating {
                 progress = CGFloat(scrollView.contentOffset.x / scrollView.frame.size.width)
-                selectedIndex = Int(roundf( Float(progress) ))
+                let nextIndex = Int(roundf(Float(progress)))
+                guard contentView.segments.indices.contains(nextIndex) else { return }
+                selectedIndex = nextIndex
             }
             
         } else {

--- a/MXSegmentedControl/MXSegmentedControl.swift
+++ b/MXSegmentedControl/MXSegmentedControl.swift
@@ -84,6 +84,14 @@ open class MXSegmentedControl: UIControl {
         }
     }
     
+    /// Indicates if the segments should fit the whole width available space when the number of segments (multiplied by each segmentWidth) 
+    /// do not cover the whole available width space. Default is `true`. 
+    @IBInspectable public var segmentsShouldFitWidthSpace: Bool = true {
+        didSet {            
+            setNeedsLayout()
+        }
+    }
+    
     /// The segmented control content insets
     @IBInspectable public dynamic var contentEdgeInsets = UIEdgeInsets.zero
     
@@ -199,7 +207,7 @@ open class MXSegmentedControl: UIControl {
         _scrollView.frame = frame
         
         let size = contentView.intrinsicContentSize
-        if size.width > frame.size.width {
+        if size.width > frame.size.width || !segmentsShouldFitWidthSpace {
             frame.size.width = size.width
         }
         


### PR DESCRIPTION
## Description
- Bug fix when scrolling sideways over the edges. When scrolling sideways, it was trying to set an a selectedIndex (left: -1 or right: segments n+1 ).
- Add the property `segmentsShouldFitWidthSpace`: Indicates if the segments should fit the whole width available space when the number of segments (multiplied by each segmentWidth) do not cover the whole available width space. Default is `true`. 

## Motivation and Context
See above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.